### PR TITLE
Ensure dashboard sidebar is visible across all pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,21 @@
 <template>
   <div id="app">
-    <router-view />
+    <NinjaSidebar v-if="showSidebar" />
+    <main :class="['app-content', { 'with-sidebar': showSidebar }]">
+      <router-view />
+    </main>
   </div>
 </template>
+
+<script setup>
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import NinjaSidebar from './components/NinjaSidebar.vue'
+
+const route = useRoute()
+
+const showSidebar = computed(() => route.name !== 'Login')
+</script>
 
 <style>
 #app {
@@ -12,6 +25,15 @@
   padding: 0;
   min-height: 100vh;
   background-color: var(--gray-50);
+}
+
+.app-content {
+  min-height: 100vh;
+  transition: margin-left 0.2s ease;
+}
+
+.app-content.with-sidebar {
+  margin-left: 280px;
 }
 
 * {

--- a/src/views/AccountDetailView.vue
+++ b/src/views/AccountDetailView.vue
@@ -281,7 +281,6 @@ export default {
 
 <style scoped>
 .account-detail-view {
-  margin-left: 280px;
   padding: 32px 40px;
   min-height: 100vh;
   background-color: #f8fafc;

--- a/src/views/CaseDetailView.vue
+++ b/src/views/CaseDetailView.vue
@@ -253,7 +253,6 @@ export default {
 
 <style scoped>
 .case-detail-view {
-  margin-left: 280px;
   padding: 32px 40px;
   min-height: 100vh;
   background-color: #f8fafc;

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -1,9 +1,5 @@
 <template>
   <div class="ninja-dashboard">
-    <!-- Left Sidebar -->
-    <NinjaSidebar />
-
-    <!-- Main Content Area -->
     <div class="main-content">
       <!-- Top Header -->
       <header class="main-header">
@@ -167,7 +163,6 @@ import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth.js'
 import { useCallsStore } from '../stores/calls.js'
 import { useBankingStore } from '../stores/banking.js'
-import NinjaSidebar from '../components/NinjaSidebar.vue'
 import ChatList from '../components/ChatList.vue'
 import LiveChatWidget from '../components/LiveChatWidget.vue'
 import ReportsWidget from '../components/ReportsWidget.vue'
@@ -178,7 +173,6 @@ let callTimer = null
 export default {
   name: 'DashboardView',
   components: {
-    NinjaSidebar,
     ChatList,
     LiveChatWidget,
     ReportsWidget
@@ -378,7 +372,6 @@ export default {
 
 <style scoped>
 .ninja-dashboard {
-  display: flex;
   min-height: 100vh;
   background: #f9fafb;
   font-family: 'Work Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -386,7 +379,6 @@ export default {
 
 .main-content {
   flex: 1;
-  margin-left: 280px;
   background: white;
   min-height: 100vh;
 }

--- a/src/views/OpportunityDetailView.vue
+++ b/src/views/OpportunityDetailView.vue
@@ -357,7 +357,6 @@ export default {
 
 <style scoped>
 .opportunity-detail-view {
-  margin-left: 280px;
   padding: 32px 40px;
   min-height: 100vh;
   background-color: #f8fafc;
@@ -391,29 +390,30 @@ export default {
   font-size: 14px;
   cursor: pointer;
   transition: all 0.2s ease;
+}
 
-    .back-btn:hover {
-      background: #e5e7eb;
-    }
+.back-btn:hover {
+  background: #e5e7eb;
+}
 
-    .opportunity-title {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-    }
+.opportunity-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
 
-    .opportunity-title h1 {
-      margin: 0;
-      font-size: 24px;
-      font-weight: 600;
-      color: #1f2937;
-    }
+.opportunity-title h1 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  color: #1f2937;
+}
 
-    .header-right {
-      display: flex;
-      gap: 12px;
-      align-items: center;
-    }
+.header-right {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
 
     .edit-btn, .opportunities-btn {
       padding: 10px 16px;

--- a/src/views/ReportsView.vue
+++ b/src/views/ReportsView.vue
@@ -459,7 +459,6 @@ export default {
 <style scoped>
 .reports-view {
   padding: 32px 40px;
-  margin-left: 280px;
   min-height: 100vh;
   background-color: #f8fafc;
 }


### PR DESCRIPTION
## Summary
- render the dashboard sidebar from the app shell on every authenticated route
- remove per-view left margins now that the sidebar offset is handled globally
- tidy the opportunity detail styles after relocating the sidebar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deec25dcd48329b4c9857ebe54f7cc